### PR TITLE
Debounce timer j w

### DIFF
--- a/webwork_addon_package.js
+++ b/webwork_addon_package.js
@@ -18,7 +18,8 @@ stylesheet.insertRule(`.obscured {filter: blur(1px) !important;}`, 2)
 stylesheet.insertRule(`.hover_position {translate: 0px 0px;}`, 3)
 
 function toggle_bigger_class_all(){
-    total_bigger = 0
+    let child = document.getElementById("live-preview")
+    let total_bigger = 0
     for(let div of answer_input){
         if(div.className.includes("bigger")){
             total_bigger++
@@ -32,6 +33,9 @@ function toggle_bigger_class_all(){
         for(let div of answer_input){
             div.classList.remove("bigger")
         }
+    }
+    if(child != null){
+        update_preview_position()
     }
 }
 
@@ -47,8 +51,12 @@ function size_changer(direction){
 }
 
 function toggle_bigger_class_by_id(){
+    let child = document.getElementById("live-preview")
     let target = document.getElementById(last_clicked)
     target.classList.toggle("bigger")
+    if(child != null){
+        update_preview_position()
+    }
 }
 
 function set_last_clicked_to_id(e){

--- a/webwork_addon_package.js
+++ b/webwork_addon_package.js
@@ -90,11 +90,32 @@ function update_preview(p_value){
         }
     }
 }
+
+function hide_preview(){
+    console.log("live preview hiding")
+    debounce(show_preview)()
+}
+
+function show_preview(){
+    console.log("live preview showing")
+}
+
+function debounce(callback) {
+    let timer
+    return function() {
+        clearTimeout(timer)
+        timer = setTimeout(() => {
+            callback();
+        }, 1000)
+    }
+}
+
 // iterate through the input boxes and attach event listeners that fire an anonymous function (j/w)
 // that listens to the input event (j/w)
 for(let input of answer_input){
     input.addEventListener("input", function(e){
         update_preview(input.value)
+        hide_preview()
     })
 }
 // I should add a hotkey to insert things into the last clicked value box such as '(()()-()())/()^2' the pattern for the quotient rule (j/w)

--- a/webwork_addon_package.js
+++ b/webwork_addon_package.js
@@ -155,7 +155,7 @@ function show_preview(){
 
 // TODO: This needs to also stop new previews from being spawned, hmmmm
 
-function enable_preview_preview(){
+function enable_preview(){
     this.preview_disabled = false
 }
 

--- a/webwork_addon_package.js
+++ b/webwork_addon_package.js
@@ -4,6 +4,7 @@ let stylesheet = document.styleSheets[0]
 let last_clicked = "init"
 let new_width = 30
 let preview_hidden = false
+let preview_disabled = false
 stylesheet.insertRule(`.bigger {width: ${new_width}rem; border: 1px solid black !important; z-index: 100000}`, 0);
 stylesheet.insertRule(`#live-preview {
     position: absolute;
@@ -152,6 +153,20 @@ function show_preview(){
     }
 }
 
+// TODO: This needs to also stop new previews from being spawned, hmmmm
+
+function enable_preview_preview(){
+    this.preview_disabled = false
+}
+
+function disable_preview(){
+    let child = document.getElementById("live-preview")
+    if(child != null){
+        child.remove()
+    }
+    this.preview_disabled = true
+}
+
 function debounce(callback) {
     let timer
     return function() {
@@ -189,6 +204,12 @@ document.addEventListener("keydown", function(e){
     }else if(e.key == "PageDown"){
         e.preventDefault()
         size_changer("down")
+    }else if(e.key == "End"){
+        e.preventDefault()
+        disable_preview()
+    }else if(e.key == "Home"){
+        e.preventDefault()
+        enable_preview()
     }
 })
 // you cannot capture print screen on keydown (j/w)

--- a/webwork_addon_package.js
+++ b/webwork_addon_package.js
@@ -13,6 +13,8 @@ stylesheet.insertRule(`#live-preview {
     padding: 5px;
     }`, 1);
 stylesheet.insertRule(`.obscured {filter: blur(1px) !important;}`, 2)
+// this is effectively a placeholder, we need to know where our hover_position rule will be to delete it
+// so we create this and insert at index 3 so we can delete it later and give it the real offsets (j/w)
 stylesheet.insertRule(`.hover_position {translate: 0px 0px;}`, 3)
 
 function toggle_bigger_class_all(){
@@ -63,25 +65,30 @@ function set_last_clicked_to_value(p_value){
     target.value = p_value
 }
 
-function spawn_preview(value){
-    // ill need the position of the parent to position the live preview, whenever I get that working (j/w)
+function update_preview_position(){
+    // all pages with a problem have a problem_body so we can use that as our attach target (j/w)
     let parent = document.getElementById("problem_body").parentElement
+    // get the offset of that target relative to the viewport (browser window) (j/w)
     let parent_x = parent.getBoundingClientRect().x
     let parent_y = parent.getBoundingClientRect().y
-
+    // we also need the relative position of the input box the user has targeted (j/w)
     let input_x = document.getElementById(last_clicked).getBoundingClientRect().x
     let input_y = document.getElementById(last_clicked).getBoundingClientRect().y
-
+    // finally offset where we spawn our live-preview by the width of the user targeted input plus 50 px for breathing room (j/w)
     let input_length = document.getElementById(last_clicked).getBoundingClientRect().width + 50
-
+    // compute the offset and save as vars for inserting into our css rule (j/w)
     let offset_x = (input_x - parent_x) + input_length
     let offset_y = input_y - parent_y
-
+    // create the new rule (j/w)
     let hover_style = `.hover_position {translate: ` + offset_x + `px ` + offset_y + `px;}`
-
+    // delete the rule and respawn it to ensure the new values are transferred (j/w)
     stylesheet.deleteRule(3)
     stylesheet.insertRule(hover_style, 3)
+}
 
+function spawn_preview(value){
+    let parent = document.getElementById("problem_body").parentElement
+    update_preview_position()
     let preview_to_spawn = document.createElement("div")
     preview_to_spawn.setAttribute("id", "live-preview")
     preview_to_spawn.textContent = "`" + value + "`"
@@ -107,6 +114,7 @@ function update_preview(p_value){
         if(v_value == ""){
             child.remove()
         }else{
+            update_preview_position()
             // this needs to be validate way better, I want fraction bars! (j/w)
             // huh, changing from $$ encapsulating to ` (backticks) gave me my fraction bars, neato (This changed to asciimath output) (j/w)
             child.textContent = "`" + v_value + "`"
@@ -115,6 +123,7 @@ function update_preview(p_value){
 }
 
 function hide_preview(){
+    // hide and show preview can probably be one toggle function instead of two discreet functions (j/w)
     let child = document.getElementById("live-preview")
     if(child != null){
         if(!preview_hidden){
@@ -125,6 +134,7 @@ function hide_preview(){
 }
 
 function show_preview(){
+    // hide and show preview can probably be one toggle function instead of two discreet functions (j/w)
     let child = document.getElementById("live-preview")
     if(child != null){
         if(preview_hidden){


### PR DESCRIPTION
Significant progress has been made: 
De bounce is functionally working in that a class is attached to the input box for 250ms after user input, currently it only blurs but that can be changed. 
The live-preview also now appears just to the right of the last used input box. 
The live preview offset follows the resize of the input boxes
End toggles the preview box off*
Home enables the preview box

Bugs:
Currently end does not disable the live preview entirely as intended, it only hides it until the next preview update